### PR TITLE
商品一覧表示の実装

### DIFF
--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,39 +125,43 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
-
+      <% @items.each do |item|%>
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+        <li class='list'>
+          <%= link_to "#" do %>
+          <div class='item-img-content'>
+            <%= image_tag item.image, class: "item-img" if item.image.attached? %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
+            <%# 商品が売れていればsold outを表示しましょう %>
+            <!--以下一時的に非表示
+            <div class='sold-out'>
             <span>Sold Out!!</span>
+            </div>
+            <%# //商品が売れていればsold outを表示しましょう %>
+            -->
           </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+          <div class='item-info'>
+            <h3 class='item-name'>
+            <%= item.products_name %>
+            </h3>
+            <div class='item-price'>
+              <span><%= item.price %>円<br>(税込み)</span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
             </div>
           </div>
-        </div>
         <% end %>
       </li>
+      <% end %>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>
+
       <li class='list'>
+      <% if @items.empty? %>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
         <div class='item-info'>
@@ -173,7 +177,9 @@
           </div>
         </div>
         <% end %>
+      <% end %>
       </li>
+      
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# /商品がない場合のダミー %>
     </ul>


### PR DESCRIPTION
#what
フリマアプリにおける商品一覧表示機能の実装
・一覧表示（画像・価格・名称）
・ログアウト時でも閲覧可能
#why
トップページにDBに登録されている商品を表示させ、購入を検討できるようにするため。